### PR TITLE
Fix shebang in ukui-kwin-5.18-move-animspeed.py

### DIFF
--- a/kconf_update/ukui-kwin-5.18-move-animspeed.py
+++ b/kconf_update/ukui-kwin-5.18-move-animspeed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import fileinput
 


### PR DESCRIPTION
This script uses 'env' as an interpreter. For the rpm runtime dependency detection to work, the shebang #!/usr/bin/env python  needs to be patched into #!/usr/bin/python  otherwise the package dependency generator merely adds a dependency on /usr/bin/env rather than the actual interpreter /usr/bin/python. Alternatively, if the file should not be executed, then ensure that it is not marked as executable or don't install it in a path that is reserved for executables.